### PR TITLE
remove header avatar css override on game detail page

### DIFF
--- a/src/media/css/game.styl
+++ b/src/media/css/game.styl
@@ -105,10 +105,6 @@
         overflow: hidden;
     }
 
-    .avatar {
-        vertical-align: middle;
-    }
-
     .leaderboard {
         background: #fff;
         float: left;


### PR DESCRIPTION
this removes a redundant css override on game detail page which causes misalignment of profile image on header.

dependency has been checked, this style does not affect anything else
