### PR TITLE
Make the arrow not show up when there are no games to navigate through

### DIFF
--- a/src/templates/_macros/featured-games.html
+++ b/src/templates/_macros/featured-games.html
@@ -17,7 +17,7 @@
         </li>
       {% endfor %}
     </ul>
-    {% if (this.length != 0) %}
+    {% if this.length > 6 %}
       <div class="arrow"></div>
     {% endif %}
     {% end %}


### PR DESCRIPTION
The arrow is not shown when there are no games that are featured. Fixes https://github.com/cvan/galaxy/issues/180.
