### PR TITLE
Fixed build_directory script for non-bash users.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "git://github.com/mozilla/galaxy.git"
   },
   "scripts": {
-    "build_directory": "pushd directory && ../node_modules/.bin/metalsmith && popd",
+    "build_directory": "/bin/bash -c 'pushd directory && ../node_modules/.bin/metalsmith && popd'",
     "dev": "gulp dev",
     "test": "NODE_ENV=test ./node_modules/.bin/mocha --require should --reporter spec --harmony --bail api/*/test.js"
   },


### PR DESCRIPTION
`pushd` and `popd` are commands specific to `bash`. For people like me using other shells, the `build_directory` script can't work as is. This makes the script run under `bash` regardless of the user's shell. 

@cvan r?
